### PR TITLE
Let ::FStext` do anchored search as intended in TECO manual

### DIFF
--- a/src/s_cmd.c
+++ b/src/s_cmd.c
@@ -86,7 +86,7 @@ static void exec_search(struct cmd *cmd, bool replace)
 
     struct search s;
 
-    if (!replace && cmd->dcolon)        // ::Stext` => (text len),1:Stext`
+    if (cmd->dcolon)                     // ::Stext` => (text len),1:Stext`
     {
         // Backwards compares always fail
 


### PR DESCRIPTION
The Standard TECO manual did not properly document the double colon modified version of FS command, but in the glossary the explaination of the term "anchored search" implied its existence. To implement this it is only required to remove the test condition that excludes dcolon been accepted in replace mode. This should fix #23 