### PR TITLE
Postpone negativity check to runtime

### DIFF
--- a/src/bracket_cmd.c
+++ b/src/bracket_cmd.c
@@ -46,6 +46,7 @@
 void exec_popQ(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (!pop_qreg(cmd->qindex))
     {
@@ -97,7 +98,7 @@ bool scan_popQ(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
 
     if (!scan_qreg(cmd))
     {

--- a/src/case_cmd.c
+++ b/src/case_cmd.c
@@ -79,6 +79,7 @@ void exec_FU(struct cmd *cmd)
 static void exec_case(struct cmd *cmd, bool lower)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     int_t dot = t->dot;
     int_t Z   = t->Z;
@@ -177,7 +178,7 @@ bool scan_case(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_COLON, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_M_ONLY, NO_COLON, NO_DCOLON, NO_ATSIGN);
 
     return false;
 }

--- a/src/ctrl_t_cmd.c
+++ b/src/ctrl_t_cmd.c
@@ -52,6 +52,7 @@
 void exec_ctrl_T(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (cmd->n_set)                     // n^T -> type out character
     {
@@ -121,7 +122,7 @@ bool scan_ctrl_T(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
 
     return false;
 }

--- a/src/ctrl_u_cmd.c
+++ b/src/ctrl_u_cmd.c
@@ -49,6 +49,7 @@
 void exec_ctrl_U(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (cmd->n_set)                     // n^Uq`?
     {
@@ -101,7 +102,7 @@ bool scan_ctrl_U(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_DCOLON);
+    confirm(cmd, NO_M_ONLY, NO_DCOLON);
 
     if (!scan_qreg(cmd))
     {

--- a/src/delete_cmd.c
+++ b/src/delete_cmd.c
@@ -47,6 +47,7 @@
 void exec_D(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     int_t n = cmd->n_arg;
     int_t m;
@@ -103,6 +104,7 @@ void exec_D(struct cmd *cmd)
 void exec_K(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (cmd->h)                         // HK?
     {
@@ -155,7 +157,7 @@ bool scan_D(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_DCOLON, NO_ATSIGN);
 
     default_n(cmd, (int_t)1);           // D => 1D
 
@@ -175,7 +177,7 @@ bool scan_K(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_COLON, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_COLON, NO_DCOLON, NO_ATSIGN);
 
     default_n(cmd, (int_t)1);           // K => 1K
 

--- a/src/fb_cmd.c
+++ b/src/fb_cmd.c
@@ -50,6 +50,7 @@ static void exec_search(struct cmd *cmd, bool replace);
 
 void exec_FB(struct cmd *cmd)
 {
+    confirm(cmd, NO_NEG_M);
     exec_search(cmd, (bool)false);
 }
 
@@ -63,6 +64,7 @@ void exec_FB(struct cmd *cmd)
 
 void exec_FC(struct cmd *cmd)
 {
+    confirm(cmd, NO_NEG_M);
     exec_search(cmd, (bool)true);
 }
 
@@ -146,7 +148,7 @@ bool scan_FB(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON);
+    confirm(cmd, NO_DCOLON);
 
     default_n(cmd, (int_t)1);           // FB => 1FB
     scan_texts(cmd, 1, ESC);
@@ -167,7 +169,7 @@ bool scan_FC(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON);
+    confirm(cmd, NO_DCOLON);
 
     default_n(cmd, (int_t)1);           // FC => 1FC
     scan_texts(cmd, 2, ESC);

--- a/src/fd_cmd.c
+++ b/src/fd_cmd.c
@@ -47,6 +47,7 @@
 void exec_FD(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (cmd->n_arg == 0)                // 0FDtext` isn't allowed
     {
@@ -102,7 +103,7 @@ bool scan_FD(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON);
+    confirm(cmd, NO_DCOLON);
 
     default_n(cmd, (int_t)1);           // FD => 1FD
     scan_texts(cmd, 1, ESC);

--- a/src/fk_cmd.c
+++ b/src/fk_cmd.c
@@ -46,6 +46,7 @@
 void exec_FK(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (cmd->text1.len != 0)
     {
@@ -85,7 +86,7 @@ bool scan_FK(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON);
+    confirm(cmd, NO_DCOLON);
 
     default_n(cmd, (int_t)1);           // FKtext` => 1FKtext`
     scan_texts(cmd, 1, ESC);

--- a/src/fr_cmd.c
+++ b/src/fr_cmd.c
@@ -53,6 +53,7 @@ uint_t last_len;
 void exec_FR(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     int_t n = cmd->n_arg;
     int_t m;
@@ -95,7 +96,7 @@ bool scan_FR(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON);
+    confirm(cmd, NO_DCOLON);
 
     default_n(cmd, -(int_t)last_len);   // FRtext` => ^SFRtext`
     scan_texts(cmd, 1, ESC);

--- a/src/goto_cmd.c
+++ b/src/goto_cmd.c
@@ -80,6 +80,7 @@ void exec_tag(struct cmd *cmd)
 void exec_O(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_N);
 
     if (cmd->n_set)                     // Computed GOTO
     {
@@ -356,7 +357,7 @@ bool scan_O(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_N, NO_M_ONLY, NO_COLON, NO_DCOLON);
+    confirm(cmd, NO_M_ONLY, NO_COLON, NO_DCOLON);
 
     scan_texts(cmd, 1, ESC);
 

--- a/src/insert_cmd.c
+++ b/src/insert_cmd.c
@@ -66,6 +66,7 @@ void exec_ctrl_I(struct cmd *cmd)
 void exec_I(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (cmd->n_set && cmd->text1.len != 0) // nItext`?
     {
@@ -158,7 +159,7 @@ bool scan_I(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_COLON, NO_DCOLON);
+    confirm(cmd, NO_M_ONLY, NO_COLON, NO_DCOLON);
 
     if (!cmd->n_set || cmd->atsign || !f.e1.insert)
     {

--- a/src/m_cmd.c
+++ b/src/m_cmd.c
@@ -226,7 +226,7 @@ bool scan_M(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_DCOLON, NO_ATSIGN);
 
     if (!scan_qreg(cmd))
     {

--- a/src/p_cmd.c
+++ b/src/p_cmd.c
@@ -48,6 +48,7 @@
 void exec_P(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     struct ofile *ofile = &ofiles[ostream];
 
@@ -216,7 +217,7 @@ bool scan_P(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_M_ONLY, NO_DCOLON, NO_ATSIGN);
 
     int c = peek_cbuf();
 

--- a/src/type_cmd.c
+++ b/src/type_cmd.c
@@ -143,6 +143,7 @@ static void exec_type(int_t m, int_t n)
 void exec_V(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     int_t m = cmd->m_arg;
     int_t n = cmd->n_arg;
@@ -209,7 +210,7 @@ bool scan_V(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_COLON, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_COLON, NO_DCOLON, NO_ATSIGN);
 
     if (!cmd->n_set || cmd->n_arg == 0) // V => 1V, 0V => 1V
     {

--- a/src/u_cmd.c
+++ b/src/u_cmd.c
@@ -45,6 +45,7 @@
 void exec_U(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     if (!cmd->n_set)                    // n argument?
     {
@@ -74,7 +75,7 @@ bool scan_U(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_M_ONLY, NO_COLON, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_M_ONLY, NO_COLON, NO_DCOLON, NO_ATSIGN);
 
     if (!scan_qreg(cmd))
     {

--- a/src/x_cmd.c
+++ b/src/x_cmd.c
@@ -46,6 +46,7 @@
 void exec_X(struct cmd *cmd)
 {
     assert(cmd != NULL);
+    confirm(cmd, NO_NEG_M);
 
     int_t n = 1;
     int_t m;
@@ -133,7 +134,7 @@ bool scan_X(struct cmd *cmd)
     assert(cmd != NULL);
 
     scan_x(cmd);
-    confirm(cmd, NO_NEG_M, NO_DCOLON, NO_ATSIGN);
+    confirm(cmd, NO_DCOLON, NO_ATSIGN);
 
     default_n(cmd, (int_t)1);           // X => 1X
 


### PR DESCRIPTION
This prevents NCA error been generated when scan for labels to goto. Also, macro invocation M should be changed to allow negative arguments.

This fixes #21 